### PR TITLE
Make perfume import dynamic for SSR

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springload/springload-analytics",
-  "version": "0.0.8",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "description": "> Google analytics tracker inspired by springload-analytics.js.",

--- a/src/plugins/performance-plugin.ts
+++ b/src/plugins/performance-plugin.ts
@@ -3,7 +3,7 @@ import perfumePlugin from '@analytics/perfumejs';
 // Track performance metrics
 const performancePlugin = ({ sendTo }: { sendTo?: string[] }) => {
   if (typeof window !== 'undefined') {
-    import('perfume.js').then((Perfume) => {
+    return import('perfume.js').then((Perfume) => {
       const destinations = Array.isArray(sendTo)
         ? sendTo.reduce((acc, tracker) => ({ ...acc, [tracker]: true }), {})
         : { all: true };
@@ -20,6 +20,7 @@ const performancePlugin = ({ sendTo }: { sendTo?: string[] }) => {
       });
     });
   }
+  return undefined;
 };
 
 export default performancePlugin;

--- a/src/plugins/performance-plugin.ts
+++ b/src/plugins/performance-plugin.ts
@@ -3,21 +3,21 @@ import perfumePlugin from '@analytics/perfumejs';
 // Track performance metrics
 const performancePlugin = ({ sendTo }: { sendTo?: string[] }) => {
   if (typeof window !== 'undefined') {
-    const Perfume = import('perfume.js');
+    import('perfume.js').then((Perfume) => {
+      const destinations = Array.isArray(sendTo)
+        ? sendTo.reduce((acc, tracker) => ({ ...acc, [tracker]: true }), {})
+        : { all: true };
 
-    const destinations = Array.isArray(sendTo)
-      ? sendTo.reduce((acc, tracker) => ({ ...acc, [tracker]: true }), {})
-      : { all: true };
-
-    return perfumePlugin({
-      perfume: Perfume,
-      category: 'perfMetrics',
-      destinations,
-      perfumeOptions: {
-        resourceTiming: true,
-        elementTiming: true,
-        maxMeasureTime: 15000,
-      },
+      return perfumePlugin({
+        perfume: Perfume,
+        category: 'perfMetrics',
+        destinations,
+        perfumeOptions: {
+          resourceTiming: true,
+          elementTiming: true,
+          maxMeasureTime: 15000,
+        },
+      });
     });
   }
 };

--- a/src/plugins/performance-plugin.ts
+++ b/src/plugins/performance-plugin.ts
@@ -1,21 +1,25 @@
-import Perfume from 'perfume.js';
 import perfumePlugin from '@analytics/perfumejs';
 
 // Track performance metrics
-const performancePlugin = ({ sendTo }: { sendTo?: string[]}) => {
-  const destinations = Array.isArray(sendTo)
-    ? sendTo.reduce((acc, tracker) => ({ ...acc, [tracker]: true }), {})
-    : { all: true };
-  return perfumePlugin({
-    perfume: Perfume,
-    category: 'perfMetrics',
-    destinations,
-    perfumeOptions: {
-      resourceTiming: true,
-      elementTiming: true,
-      maxMeasureTime: 15000,
-    },
-  });
+const performancePlugin = ({ sendTo }: { sendTo?: string[] }) => {
+  if (typeof window !== 'undefined') {
+    const Perfume = import('perfume.js');
+
+    const destinations = Array.isArray(sendTo)
+      ? sendTo.reduce((acc, tracker) => ({ ...acc, [tracker]: true }), {})
+      : { all: true };
+
+    return perfumePlugin({
+      perfume: Perfume,
+      category: 'perfMetrics',
+      destinations,
+      perfumeOptions: {
+        resourceTiming: true,
+        elementTiming: true,
+        maxMeasureTime: 15000,
+      },
+    });
+  }
 };
 
 export default performancePlugin;

--- a/src/springloadAnalytics.ts
+++ b/src/springloadAnalytics.ts
@@ -72,7 +72,7 @@ export const init = ({
   options = { ...options, ...overrideOptions };
   analyInstance = Analytics({
     app: 'springload-analytics',
-    plugins: trackerPlugins,
+    plugins: trackerPlugins.filter(Boolean),
     debug,
   });
 };


### PR DESCRIPTION
Currently Next.JS builds with Server Side Rendering fail when attempting to use `springload-analytics` as the Perfume library makes use of the `window` object that isn't present when the browser is not available.

From some research the most widely used and accepted approach to SSR seems to be dynamically importing libraries that use the `window` object with using a conditional statement on `(typeof window !== 'undefined')`

I've added this in at the library level along with a filter on the `trackerPlugins` array so that when the browser is being used then the performance library can be used but then the route is being rendered on the server the performance library won't load.

This allows the main app that utilises the `springload-analytics` library to be agnostic of whether the render mode is SSR or CSR. And continue to use the following syntax without changes:

```
Analytics.init({
  trackerPlugins: [
    Analytics.performancePlugin(),
  ],
});
```